### PR TITLE
Colon in claim name and JSON type claim value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -191,11 +191,13 @@ func (c claimMappingsT) fromFile(path string) error {
 func (c claimMappingsT) fromString(val string) error {
 	mappings := strings.Split(val, ",")
 	for _, mapping := range mappings {
-		pair := strings.Split(mapping, ":")
-		if len(pair) != 2 {
+		lastInd := strings.LastIndex(mapping, ":")
+		if lastInd == -1 {
 			return fmt.Errorf("unexpected number of ':' in claim mapping '%s'", mapping)
 		}
-		c[pair[0]] = pair[1]
+		key := mapping[:lastInd]
+		value := mapping[lastInd+1:]
+		c[key] = value
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,14 +17,15 @@ import (
 
 var (
 	claims = map[string]interface{}{
-		"claim1": "claim value 1",
-		"claim2": "claim value 2",
-		"claim3": "claim value 3",
+		"claim1":  "claim value 1",
+		"claim2":  "claim value 2",
+		"claim:3": "claim value 3",
 	}
-	claimMappingString = "claim1:claimHeader1,claim2:claimHeader2"
+	claimMappingString = "claim1:claimHeader1,claim2:claimHeader2,claim:3:claimHeader3"
 	claimMappingMap    = map[string]string{
-		"claim1": "claimHeader1",
-		"claim2": "claimHeader2",
+		"claim1":  "claimHeader1",
+		"claim2":  "claimHeader2",
+		"claim:3": "claimHeader3",
 	}
 )
 
@@ -73,7 +74,7 @@ func TestMergeClaimMappingsFileAndEnv(t *testing.T) {
 	dt.HandleByPanic(err)
 	defer os.Remove(file.Name())
 	json.NewEncoder(file).Encode(map[string]string{"claim1": "claimHeader1"})
-	os.Setenv(c.ClaimMappingsEnv, "claim2:claimHeader2")
+	os.Setenv(c.ClaimMappingsEnv, "claim2:claimHeader2,claim:3:claimHeader3")
 	os.Setenv(c.ClaimMappingFileEnv, file.Name())
 	validateCorrectSetup(t, tc, c.AuthHeaderDefault)
 }
@@ -89,7 +90,7 @@ func validateCorrectSetup(t *testing.T, tc *dt.TestConfig, authKey string) {
 	dt.HandleByPanic(err)
 	dt.Report(t, resp.Header.Get("claimHeader1") != claims["claim1"], "incorrect header for claim1")
 	dt.Report(t, resp.Header.Get("claimHeader2") != claims["claim2"], "incorrect header for claim2")
-	dt.Report(t, resp.Header.Get("claimHeader3") != "", "incorrect header for claim2")
+	dt.Report(t, resp.Header.Get("claimHeader3") != claims["claim:3"], "incorrect header for claim:3")
 	validateMetrics(t, port)
 	err = l.Close()
 	dt.HandleByPanic(err)

--- a/decoder/jws.go
+++ b/decoder/jws.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/jwk"
@@ -51,7 +52,13 @@ func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) 
 			if strVal, ok := value.(string); ok {
 				token.Claims[destKey] = strVal
 			} else {
-				return nil, UnexpectedClaimTypeError{key, value}
+				strJson, err := json.Marshal(value)
+
+				if err != nil {
+					return nil, UnexpectedClaimTypeError{key, value}
+				}
+
+				token.Claims[destKey] = string(strJson)
 			}
 		}
 	}

--- a/decoder/jws.go
+++ b/decoder/jws.go
@@ -52,13 +52,13 @@ func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) 
 			if strVal, ok := value.(string); ok {
 				token.Claims[destKey] = strVal
 			} else {
-				strJson, err := json.Marshal(value)
+				strJSON, err := json.Marshal(value)
 
 				if err != nil {
 					return nil, UnexpectedClaimTypeError{key, value}
 				}
 
-				token.Claims[destKey] = string(strJson)
+				token.Claims[destKey] = string(strJSON)
 			}
 		}
 	}

--- a/decoder/jws_test.go
+++ b/decoder/jws_test.go
@@ -29,6 +29,6 @@ func TestTokenWithInvalidClaims(t *testing.T) {
 	for k, v := range invalidTokens {
 		token := tc.NewValidToken(map[string]interface{}{claimKey: v})
 		resp, err := dec.Decode(dt.Ctx(), string(token))
-		dt.Report(t, err == nil, "able to decode token with unexpected type: (%s : %+v) into %+v", k, v, resp)
+		dt.Report(t, err != nil, "not able to decode token with unusual JSON type: (%s : %+v) into %+v", k, v, resp)
 	}
 }

--- a/decoder/server_test.go
+++ b/decoder/server_test.go
@@ -2,6 +2,7 @@ package decoder_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	rnd "math/rand"
 	"net/http"
@@ -24,16 +25,22 @@ const (
 )
 
 var (
-	allClaims = map[string]string{
+	allClaims = map[string]interface{}{
 		"claim1":     "claim number 1",
 		"claim2":     "claim number 2",
 		"claim3":     "claim number 3",
+		"claim:4":    "claim number 4",
+		"claim5":     []string{"claim number 5"},
+		"claim6":     map[string]string{"claim": "number 6"},
 		"otherClaim": "this-claim-is-not-set",
 	}
 	claimMappings = map[string]string{
 		"claim1":    "test-token-claim1",
 		"claim2":    "test-token-claim2",
 		"claim3":    "test-token-claim3",
+		"claim:4":   "test-token-claim4",
+		"claim5":    "test-token-claim5",
+		"claim6":    "test-token-claim6",
 		randomClaim: randomClaimHeader,
 	}
 )
@@ -94,6 +101,12 @@ func TestServerResponseHeaders(t *testing.T) {
 				}
 				headerVal := headers.Get(headerKey)
 				claimVal := allClaims[claimKey]
+				if strVal, ok := claimVal.(string); ok {
+					claimVal = strVal
+				} else {
+					strJson, _ := json.Marshal(claimVal)
+					claimVal = string(strJson)
+				}
 				dt.Report(t, headerVal != claimVal, "claim '%s=%s' has incorrect val '%s=%s'", claimKey, claimVal, headerKey, headerVal)
 			}
 		}


### PR DESCRIPTION
As an example, AWS Cognito JWT token contains `"cognito:groups": ["group1"]` as claim and it is also possible to see JSON object as claim values.

Code is updated to support following ENV var esp. docker config:
`CLAIM_MAPPINGS: "sub:x-user-id,cognito:groups:x-user-groups,username:x-user-name"`

In addition, any JSON parsable value is forwarded as JSON string in the mapped header key