### PR TITLE
Feature/lazy jwks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,6 +94,7 @@ LOG_LEVEL                  = info                = trace | debug | info | warn |
 LOG_TYPE                   = json                = json | pretty
 MAX_CACHE_KEYS             = 10000
 CACHE_ENABLED              = true
+FORCE_JWKS_ON_START        = true
 ```
 
 optional configurations

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 const (
 	JwksURLEnv                  = "JWKS_URL"
 	ForceJwksOnStart            = "FORCE_JWKS_ON_START"
-	ForceJwksOnStartDefault     = "false"
+	ForceJwksOnStartDefault     = "true"
 	ClaimMappingFileEnv         = "CLAIM_MAPPING_FILE_PATH"
 	ClaimMappingFileDefault     = "config.json"
 	AuthHeaderEnv               = "AUTH_HEADER_KEY"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -144,7 +144,17 @@ func TestFailsOnBadJwksURL(t *testing.T) {
 	tc := dt.NewTest()
 	defaultEnv(tc)
 	os.Setenv(c.JwksURLEnv, "http://non-existing/.jwks.url")
+	os.Setenv(c.ForceJwksOnStart, "true")
 	validatePanicsWhenStarting(t)
+}
+
+func TestWarningOnBadJwksURL(t *testing.T) {
+	os.Clearenv()
+	tc := dt.NewTest()
+	defaultEnv(tc)
+	os.Setenv(c.JwksURLEnv, "http://non-existing/.jwks.url")
+	os.Setenv(c.ForceJwksOnStart, "false")
+	validateWarningWhenStarting(t)
 }
 
 func TestFailsOnBadLogLevel(t *testing.T) {
@@ -162,6 +172,17 @@ func validatePanicsWhenStarting(t *testing.T) {
 			return
 		}
 		t.Fatal("function did not panic")
+	}()
+	c.NewConfig().RunServer()
+}
+
+func validateWarningWhenStarting(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Logf("function recovered")
+			return
+		}
+		t.Fatal("function did not recover")
 	}()
 	c.NewConfig().RunServer()
 }

--- a/decoder/jws.go
+++ b/decoder/jws.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
@@ -14,6 +15,7 @@ type jwsDecoder struct {
 	jwks         *jwk.Set
 	claimMapping map[string]string
 	jwksURL      string
+	mutex        sync.RWMutex
 }
 
 // UnexpectedClaimTypeError is thrown if a mapped claim in the token has an unexpected type
@@ -27,22 +29,28 @@ func (e UnexpectedClaimTypeError) Error() string {
 	return fmt.Sprintf("claim %s has type %T not string", e.name, e.claim)
 }
 
-// TryFetchingJwks is shared among function to implement lazy fetching of JWKS
-func TryFetchingJwks(jwksURL string) (*jwk.Set, error) {
-	return jwk.FetchHTTP(jwksURL)
-}
-
 // NewJwsDecoder returns a root Decoder that can decode and validate JWS Tokens
 // It will also map the claims via the claim mapping
 // `claimMapping = map[string][string]{ "key123", "headerKey123" }`
 // will cause the claim `key123` in the JWS token to be mapped to `headerKey123` in the decoded token
 func NewJwsDecoder(jwksURL string, claimMapping map[string]string) (TokenDecoder, error) {
-	jwks, err := TryFetchingJwks(jwksURL)
-	if err != nil {
-		jwks = nil
-		err = fmt.Errorf("jwks: failed to fetch from url %s: %w", jwksURL, err)
+	d := jwsDecoder{claimMapping: claimMapping, jwksURL: jwksURL}
+	_, err := d.getJWKs()
+	return &d, err
+}
+
+func (d *jwsDecoder) getJWKs() (*jwk.Set, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if d.jwks != nil {
+		return d.jwks, nil
 	}
-	return &jwsDecoder{jwks: jwks, claimMapping: claimMapping, jwksURL: jwksURL}, err
+	jwks, err := jwk.FetchHTTP(d.jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("jwks: failed to fetch from url %s: %w", d.jwksURL, err)
+	}
+	d.jwks = jwks
+	return d.jwks, nil
 }
 
 func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) {
@@ -73,14 +81,11 @@ func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) 
 }
 
 func (d *jwsDecoder) parseAndValidate(rawJws string) (jwt.Token, error) {
-	if d.jwks == nil {
-		jwks, err := TryFetchingJwks(d.jwksURL)
-		if err != nil {
-			return nil, fmt.Errorf("jwks: failed to fetch from url %s: %w", d.jwksURL, err)
-		}
-		d.jwks = jwks
+	jwks, err := d.getJWKs()
+	if err != nil {
+		return nil, err
 	}
-	_, err := jws.VerifyWithJWKSet([]byte(rawJws), d.jwks, nil)
+	_, err = jws.VerifyWithJWKSet([]byte(rawJws), jwks, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify token with jwks: %w", err)
 	}

--- a/decoder/jws.go
+++ b/decoder/jws.go
@@ -13,6 +13,7 @@ import (
 type jwsDecoder struct {
 	jwks         *jwk.Set
 	claimMapping map[string]string
+	jwksURL      string
 }
 
 // UnexpectedClaimTypeError is thrown if a mapped claim in the token has an unexpected type
@@ -26,16 +27,22 @@ func (e UnexpectedClaimTypeError) Error() string {
 	return fmt.Sprintf("claim %s has type %T not string", e.name, e.claim)
 }
 
+// TryFetchingJwks is shared among function to implement lazy fetching of JWKS
+func TryFetchingJwks(jwksURL string) (*jwk.Set, error) {
+	return jwk.FetchHTTP(jwksURL)
+}
+
 // NewJwsDecoder returns a root Decoder that can decode and validate JWS Tokens
 // It will also map the claims via the claim mapping
 // `claimMapping = map[string][string]{ "key123", "headerKey123" }`
 // will cause the claim `key123` in the JWS token to be mapped to `headerKey123` in the decoded token
 func NewJwsDecoder(jwksURL string, claimMapping map[string]string) (TokenDecoder, error) {
-	jwks, err := jwk.FetchHTTP(jwksURL)
+	jwks, err := TryFetchingJwks(jwksURL)
 	if err != nil {
-		return nil, fmt.Errorf("jwks: failed to fetch from url %s: %w", jwksURL, err)
+		jwks = nil
+		err = fmt.Errorf("jwks: failed to fetch from url %s: %w", jwksURL, err)
 	}
-	return &jwsDecoder{jwks: jwks, claimMapping: claimMapping}, nil
+	return &jwsDecoder{jwks: jwks, claimMapping: claimMapping, jwksURL: jwksURL}, err
 }
 
 func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) {
@@ -66,6 +73,13 @@ func (d *jwsDecoder) Decode(ctx context.Context, rawJws string) (*Token, error) 
 }
 
 func (d *jwsDecoder) parseAndValidate(rawJws string) (jwt.Token, error) {
+	if d.jwks == nil {
+		jwks, err := TryFetchingJwks(d.jwksURL)
+		if err != nil {
+			return nil, fmt.Errorf("jwks: failed to fetch from url %s: %w", d.jwksURL, err)
+		}
+		d.jwks = jwks
+	}
 	_, err := jws.VerifyWithJWKSet([]byte(rawJws), d.jwks, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify token with jwks: %w", err)

--- a/decoder/jws_test.go
+++ b/decoder/jws_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/SimonSchneider/traefik-jwt-decode/decoder"
 )
 
-func TestInvalidJwksURLFailsFast(t *testing.T) {
+func TestInvalidJwksURLGivesWarning(t *testing.T) {
 	claimMapping := make(map[string]string)
-	_, err := decoder.NewJwsDecoder("https://this.com/does/not/exist", claimMapping)
-	dt.Report(t, err == nil, "able to create jws decoder with incorrect jwks url")
+	dec, err := decoder.NewJwsDecoder("https://this.com/does/not/exist", claimMapping)
+	dt.Report(t, dec == nil && err == nil, "not able to create jws decoder with incorrect jwks url, and no warning given")
 }
 
 func TestTokenWithInvalidClaims(t *testing.T) {

--- a/decoder/jws_test.go
+++ b/decoder/jws_test.go
@@ -14,6 +14,12 @@ func TestInvalidJwksURLGivesWarning(t *testing.T) {
 	dt.Report(t, dec == nil && err == nil, "not able to create jws decoder with incorrect jwks url, and no warning given")
 }
 
+func TestValidJwksURL(t *testing.T) {
+	claimMapping := make(map[string]string)
+	dec, err := decoder.NewJwsDecoder("https://www.googleapis.com/oauth2/v3/certs", claimMapping)
+	dt.Report(t, dec == nil || err != nil, "not able to create jws decoder with correct jwks url")
+}
+
 func TestTokenWithInvalidClaims(t *testing.T) {
 	invalidTokens := map[string]interface{}{
 		"int":    123,


### PR DESCRIPTION
The service tries to fetch JWKS on startup and fails if the link is not available. 

In case, when the JWKS is provided by another microservice that service can be down or better, it is not yet discovered by the traefik. Namely, if you would like to fetch JWKS by using traefik's router which is an internal unsecure route, the decode service fails and also may prevent traefik to start as well (in case traefik docker-compose links to decode service)

This fix add an option postpone fetching JWKS when there is a request and tries with every request until it is available. `FORCE_JWKS_ON_START` controls the behaviour.

